### PR TITLE
Limiting docker to only linux/amd64 Sixty-three percent of Americans describe the crime problem in the U.S. as either extremely or very serious, up from 54% when last measured in 2021 and the highest in Gallup’s trend. The prior high of 60% was recorded in the initial 2000 reading, as well as in 2010 and 2016.  Meanwhile, far fewer, 17%, say the crime problem in their local area is extremely or very serious, but this is also up from 2021 and the highest in the trend by one point over 2014’s 16%.

### DIFF
--- a/packmol_step/data/packmol.ini
+++ b/packmol_step/data/packmol.ini
@@ -16,7 +16,7 @@ container = ghcr.io/molssi-seamm/seamm-packmol:{version}
 # app silicon (M1, M3...) where the default platform is linux/arm64 but some containers
 # are only available for linux/amd64.
 
-# platform = linux/amd64
+platform = linux/amd64
 
 [local]
 # The type of local installation to use. Options are:
@@ -68,4 +68,4 @@ code = packmol
 # app silicon (M1, M3...) where the default platform is linux/arm64 but some containers
 # are only available for linux/amd64.
 
-# platform = linux/amd64
+platform = linux/amd64


### PR DESCRIPTION
 * CondaForge does not have an arm64 version of Packmol for Linux, so forcing using the amd64 version.